### PR TITLE
Fix hotkey QuickForm forwarding TAB

### DIFF
--- a/Sledge.Editor/Settings/SettingsForm.cs
+++ b/Sledge.Editor/Settings/SettingsForm.cs
@@ -1862,10 +1862,10 @@ namespace Sledge.Editor.Settings
                 .Item(new HotkeyQuickFormItem("Hotkey", hk.HotkeyString))
                 .OkCancel())
             {
+                qf.ForwardTabKey = false;
                 if (qf.ShowDialog() != DialogResult.OK) return;
                 var key = qf.String("Hotkey");
                 if (String.IsNullOrWhiteSpace(key)) return;
-
                 var conflict = _hotkeys.FirstOrDefault(x => x.HotkeyString == key && x != hk);
                 if (conflict != null)
                 {

--- a/Sledge.QuickForms/QuickForm.cs
+++ b/Sledge.QuickForms/QuickForm.cs
@@ -36,6 +36,7 @@ namespace Sledge.QuickForms
 	    public int LabelWidth { get; set; }
 
 	    public bool UseShortcutKeys { get; set; }
+        public bool ForwardTabKey { get; set; }
 
         /// <summary>
         /// Create a form with the specified title.
@@ -52,6 +53,7 @@ namespace Sledge.QuickForms
 			MinimizeBox = false;
 			MaximizeBox = false;
             UseShortcutKeys = false;
+            ForwardTabKey = true;
             KeyPreview = true;
 	    }
 
@@ -80,7 +82,15 @@ namespace Sledge.QuickForms
             if (nonlabel != null) nonlabel.Focus();
 			base.OnLoad(e);
 		}
-		
+
+        protected override bool ProcessTabKey(bool forward)
+        {
+            if (!ForwardTabKey)
+                return false;
+            else
+                return base.ProcessTabKey(forward);
+        }
+
         /// <summary>
         /// Add an item to the form.
         /// </summary>


### PR DESCRIPTION
It didn't capture TABs like the main form does.